### PR TITLE
fix: default excluded revset to empty string

### DIFF
--- a/lua/jiejie/config.lua
+++ b/lua/jiejie/config.lua
@@ -6,7 +6,7 @@
 
 --- @type Configuration
 local DEFAULT_CONFIG = {
-  excluded_revset = nil,
+  excluded_revset = "",
   -- default_view = 1,
   dynamic_views = {},
   log_revisions = 10,


### PR DESCRIPTION
With the documented minimal setup, no user config is passed, so `excluded_revset` kept the default `nil`. The log builder compares that value to `""` and then concatenates it into the revset, which crashes the first `:J` / default log open before any buffer renders.

Use `""` as the no-op revset so the existing exclusion guard can skip revset filtering unless the user configured an exclusion.

## Test plan

### Automated

In [another branch](https://github.com/jceb/jiejie.nvim/compare/main...john-kurkowski:jiejie.nvim:startup-regression-coverage?expand=1), I added integration test coverage to catch this. But that seemed like a more invasive change. Let me know if you'd like me to open a PR for that.

### Manual

1. Configure this plugin with the README's minimal instructions.
2. Run `:J`.